### PR TITLE
Add ap-southeast-6 (New Zealand) region to cfnResourceSpecs

### DIFF
--- a/cfnResourceSpecs.json
+++ b/cfnResourceSpecs.json
@@ -31,6 +31,7 @@
     "sa-east-1": "https://d3c9jyj3w509b0.cloudfront.net/latest/gzip/CloudFormationResourceSpecification.json",
     "us-gov-east-1": "https://s3.us-gov-east-1.amazonaws.com/cfn-resource-specifications-us-gov-east-1-prod/latest/CloudFormationResourceSpecification.json",
     "us-gov-west-1": "https://s3.us-gov-west-1.amazonaws.com/cfn-resource-specifications-us-gov-west-1-prod/latest/CloudFormationResourceSpecification.json",
-    "ap-southeast-7": "https://cfn-resource-specifications-ap-southeast-7-767397843873-prod.s3.ap-southeast-7.amazonaws.com/latest/CloudFormationResourceSpecification.json"
+    "ap-southeast-7": "https://cfn-resource-specifications-ap-southeast-7-767397843873-prod.s3.ap-southeast-7.amazonaws.com/latest/CloudFormationResourceSpecification.json",
+    "ap-southeast-6": "https://s3.ap-southeast-6.amazonaws.com/cfn-resource-specifications-ap-southeast-6-394393102373-prod/latest/gzip/CloudFormationResourceSpecification.json"
   }
   


### PR DESCRIPTION
## Summary
Added CloudFormation resource specification URL for the ap-southeast-6 (New Zealand) region to enable service/feature comparison capabilities.

## Changes
- Added ap-southeast-6 region entry to cfnResourceSpecs.json
- Enables the region migration tools to compare CloudFormation resources and properties for the New Zealand region

## Impact
- Users can now perform service/feature comparisons involving the ap-southeast-6 region
- Supports migration planning to/from the New Zealand region

## Testing
- Verified the CloudFormation resource specification URL is accessible
- Confirmed JSON syntax remains valid after the addition